### PR TITLE
fixed image link in 'fork me on github' snippet

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -286,7 +286,7 @@ describe('File System', function(){
 
     </div><!-- /container -->
 
-    <a href='http://github.com/alexeypetrushin/synchronize'><img style='position: absolute; top: 0; right: 0; border: 0; z-index: 2080;'  src='https://a248.e.akamai.net/assets.github.com/img/71eeaab9d563c2b3c590319b398dd35683265e85/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f677261795f3664366436642e706e67' alt='Fork me on GitHub'></a>
+    <a href='https://github.com/alexeypetrushin/synchronize'><img style='position: absolute; top: 0; right: 0; border: 0;' src='https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png' alt='Fork me on GitHub'></a>
 
     <!-- Scripts -->
     <script src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'></script>


### PR DESCRIPTION
more details in issue #10

this fixes the broken image link, keeping the use of single quotes, but changing the link to use https and removing the z-index setting, just going by the snippets at the github ribbons page @ https://github.com/blog/273-github-ribbons
