### PR TITLE
Add can receive multiple arguments defer function

### DIFF
--- a/test/sync.js
+++ b/test/sync.js
@@ -126,6 +126,49 @@ describe('Control Flow', function(){
     }, done)
   })
 
+  it('should support multiple arguments', function(done){
+    sync.fiber(function(){
+      var read = function(cb){
+        process.nextTick(function(){
+          cb(null, 'data1', 'data2')
+        })
+      }
+
+      var result = sync.await(read(sync.defers()))
+      expect(result).to.eql(['data1', 'data2'])
+    }, done)
+  })
+
+  it('should support multiple `named` arguments', function(done){
+    sync.fiber(function(){
+      var read = function(cb){
+        process.nextTick(function(){
+          cb(null, 'data1', 'data2')
+        })
+      }
+
+      var result = sync.await(read(sync.defers('a', 'b')))
+      expect(result).to.eql({a: 'data1', b: 'data2'})
+    }, done)
+  })
+
+  it('should support multiple arguments parallel calls', function(done){
+    sync.fiber(function(){
+      var read = function(cb){
+        process.nextTick(function(){
+          cb(null, 'data1', 'data2')
+        })
+      }
+
+      sync.parallel(function(){
+        read(sync.defers())
+        read(sync.defers('a', 'b'))
+      })
+      var results = sync.await()
+      expect(results).to.eql([['data1', 'data2'], {a: 'data1', b: 'data2'}])
+    }, done)
+  })
+
   beforeEach(function(){
     this.someKey = 'some value'
   })


### PR DESCRIPTION
This patch implement issue #9 ideas of @jric and @vjpr

`sync.defers` is special type defer function.
If use normally like `sync.defers()`, it may return array have all arguments(except err)
If pass keywords like `sync.defers('a', 'b', 'c')`, it may return object mapped arguments.
