### PR TITLE
Fix final callback callable twice

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -235,13 +235,14 @@ sync.fiber = function(cb, done){
   var that = this
   Fiber(function(){
     if (done) {
+      var result
       try {
-        var result = cb.call(that)
+        result = cb.call(that)
         Fiber.current._syncIsTerminated = true
-        done(null, result)
       } catch (error){
-        done(error)
+        return done(error)
       }
+      done(null, result)
     } else {
       // Don't catch errors if done not provided!
       cb.call(that)

--- a/test/sync.js
+++ b/test/sync.js
@@ -314,6 +314,19 @@ describe('Control Flow', function(){
     }, 10)
   })
 
+  it('should call terminate callback just once', function(done) {
+    var callCount = 0
+    var callback = function(error) {
+      callCount += 1
+      throw new Error('some error')
+    }
+    expect(function() {sync.fiber(function() {}, callback)}).to.throw(Error)
+    setTimeout(function() {
+      expect(callCount).to.eql(1)
+      done()
+    }, 10)
+  })
+
   beforeEach(function(){
     this.someKey = 'some value'
   })


### PR DESCRIPTION
If `done` raise error on sync action, fiber should recall this.
This error should catch outside of fiber.

or `done` should wrap new function and new function can raise special error like `express` response. (`express` raise `Callback was already called` error)
