### PR TITLE
sync.deferWithTimeout should check if there is a fiber first.

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -66,7 +66,7 @@ sync.defer = function(){
 // Exactly the same as defer, but additionally it triggers an error if there's no response
 // on time.
 sync.deferWithTimeout = function(timeout, message){
-  if(!Fiber.current) throw new Error("no current Fiber, defer can't be used without Fiber!")
+  if(!Fiber.current) throw new Error("no current Fiber, deferWithTimeout can't be used without Fiber!")
   if(!timeout) throw new Error("no timeout provided!")
   if(Fiber.current._syncParallel) throw new Error("deferWithTimeout can't be used in parallel!")
 

--- a/sync.js
+++ b/sync.js
@@ -66,6 +66,7 @@ sync.defer = function(){
 // Exactly the same as defer, but additionally it triggers an error if there's no response
 // on time.
 sync.deferWithTimeout = function(timeout, message){
+  if(!Fiber.current) throw new Error("no current Fiber, defer can't be used without Fiber!")
   if(!timeout) throw new Error("no timeout provided!")
   if(Fiber.current._syncParallel) throw new Error("deferWithTimeout can't be used in parallel!")
 


### PR DESCRIPTION
sync.deferWithTimeout should do the same fiber check that sync.defer does. Currently the code throws a `TypeError: Cannot read property '_syncParallel' of undefined` if you aren't inside of a Fiber.