### PR TITLE
Prevent multiple restart fiber action

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -92,10 +92,16 @@ sync.deferSerial = function(){
   var fiber = Fiber.current
   if(!fiber) throw new Error("no current Fiber, defer can't be used without Fiber!")
 
+  // Prevent recursive call
+  var called = 0
   // Returning asynchronous callback.
   return function(err, result){
+    called += 1
+    if (called > 1) throw new Error("defer can't use twice")
+
     // Wrapping in nextTick as a safe measure against not asynchronous usage.
     process.nextTick(function(){
+      if(called > 1) return
       if(fiber._syncIsTerminated) return
       if(err){
         // Resuming fiber and throwing error.
@@ -150,11 +156,17 @@ sync.defersSerial = function(){
   if(!fiber) throw new Error("no current Fiber, defer can't be used without Fiber!")
 
   var kwds = Array.prototype.slice.call(arguments)
+
+  // Prevent recursive call
+  var called = 0
   // Returning asynchronous callback.
   return function(err) {
+    called += 1
+    if (called > 1) throw new Error("defer can't use twice")
     // Wrapping in nextTick as a safe measure against not asynchronous usage.
     var args = Array.prototype.slice.call(arguments, 1)
     process.nextTick(function(){
+      if(called > 1) return
       if(fiber._syncIsTerminated) return
       if (err) {
         // Resuming fiber and throwing error.

--- a/sync.js
+++ b/sync.js
@@ -91,7 +91,8 @@ sync.deferWithTimeout = function(timeout, message){
 sync.deferSerial = function(){
   var fiber = Fiber.current
   if(!fiber) throw new Error("no current Fiber, defer can't be used without Fiber!")
-
+  if(fiber._defered) throw new Error("invalid usage, should be clear previous defer!")
+  fiber._defered = true
   // Prevent recursive call
   var called = 0
   // Returning asynchronous callback.
@@ -102,6 +103,7 @@ sync.deferSerial = function(){
     // Wrapping in nextTick as a safe measure against not asynchronous usage.
     process.nextTick(function(){
       if(called > 1) return
+      fiber._defered = false
       if(fiber._syncIsTerminated) return
       if(err){
         // Resuming fiber and throwing error.
@@ -154,6 +156,8 @@ sync.defers = function(){
 sync.defersSerial = function(){
   var fiber = Fiber.current;
   if(!fiber) throw new Error("no current Fiber, defer can't be used without Fiber!")
+  if(fiber._defered) throw new Error("invalid usage, should be clear previous defer!")
+  fiber._defered = true
 
   var kwds = Array.prototype.slice.call(arguments)
 
@@ -167,6 +171,7 @@ sync.defersSerial = function(){
     var args = Array.prototype.slice.call(arguments, 1)
     process.nextTick(function(){
       if(called > 1) return
+      fiber._defered = false
       if(fiber._syncIsTerminated) return
       if (err) {
         // Resuming fiber and throwing error.
@@ -249,7 +254,9 @@ sync.parallel = function(cb){
 // if `done` not provided it will be just rethrown.
 sync.fiber = function(cb, done){
   var that = this
-  Fiber(function(){
+  var fiber = Fiber(function(){
+    // Prevent restart fiber
+    if (fiber._started) return
     if (done) {
       var result
       try {
@@ -264,7 +271,9 @@ sync.fiber = function(cb, done){
       cb.call(that)
       Fiber.current._syncIsTerminated = true
     }
-  }).run()
+  })
+  fiber.run()
+  fiber._started = true
 }
 
 // Asynchronous wrapper for mocha.js tests.

--- a/test/sync.js
+++ b/test/sync.js
@@ -379,6 +379,33 @@ describe('Control Flow', function(){
     })
   })
 
+  it('should prevent restart fiber', function(done){
+    var currentFiber
+    var called = 0
+    sync.fiber(function(){
+      called += 1
+      currentFiber = sync.Fiber.current
+    })
+    setTimeout(function() {
+      currentFiber.run()
+    }, 1)
+    setTimeout(function() {
+      expect(called).to.eql(1)
+      done()
+    }, 10);
+  })
+
+  it('should raise error when not matched defer-await pair', function(done){
+    sync.fiber(function(){
+	    process.nextTick(sync.defer());
+      expect(function() { process.nextTick(sync.defer()) }).to.throw(Error)
+      sync.await()
+	    process.nextTick(sync.defers());
+      expect(function() { process.nextTick(sync.defers()) }).to.throw(Error)
+      sync.await()
+    }, done)
+  })
+
   beforeEach(function(){
     this.someKey = 'some value'
   })

--- a/test/sync.js
+++ b/test/sync.js
@@ -327,6 +327,58 @@ describe('Control Flow', function(){
     }, 10)
   })
 
+  it('should be raise error at call defer twice', function(done){
+    sync.fiber(function(){
+      var defer = sync.defer()
+      defer()
+      sync.await()
+      expect(defer).to.throw(Error)
+    }, done)
+  })
+
+  it('should call defer just once in fiber process', function(done){
+    var broken = function(cb) {
+      sync.fiber(function() {
+        cb()
+      }, cb)
+    }
+    sync.fiber(function(){
+      broken(sync.defer())
+      sync.await()
+      throw new Error('an error')
+    }, function(err) {
+      expect(err).to.exist
+      expect(err.message).to.eql("defer can't use twice")
+      done()
+    })
+  })
+
+  it('should be raise error at call defers twice', function(done){
+    sync.fiber(function(){
+      var defer = sync.defers()
+      defer()
+      sync.await()
+      expect(defer).to.throw(Error)
+    }, done)
+  })
+
+  it('should prevent defers call just once in fiber process', function(done){
+    var broken = function(cb) {
+      sync.fiber(function() {
+        cb()
+      }, cb)
+    }
+    sync.fiber(function(){
+      broken(sync.defers())
+      sync.await()
+      throw new Error('an error')
+    }, function(err) {
+      expect(err).to.exist
+      expect(err.message).to.eql("defer can't use twice")
+      done()
+    })
+  })
+
   beforeEach(function(){
     this.someKey = 'some value'
   })


### PR DESCRIPTION
If we make wrong fiber process, it cause insane result.

This patch set prevent these case:

1. multiple recall defer
2. multiple restart fiber

These problems are probably user's fault, but library raise error, it will help to find errors.