### PR TITLE
Prevent the fiber from unwinding if `await` is called after an empty `parallel` block.

### DIFF
--- a/test/sync.js
+++ b/test/sync.js
@@ -1,3 +1,5 @@
+/*jshint node: true, indent:2, loopfunc: true, asi: true, undef:true, mocha: true */
+
 // require('longjohn')
 
 var sync   = require('../sync')

--- a/test/sync.js
+++ b/test/sync.js
@@ -250,6 +250,16 @@ describe('Control Flow', function(){
     }, done)
   })
 
+  it('should not unwind when await is called after an empty parallel block', function(done){
+    sync.fiber(function(){
+      sync.parallel(function(){
+        // Imagine that the user intends to enumerate an array here, calling
+        // `defer` once per array item, but the array is empty.
+      })
+      expect(sync.await()).to.eql([])
+    }, done)
+  })
+
   it('should return result from fiber', function(done){
     sync.fiber(function(){
       return 'some value'


### PR DESCRIPTION
Fixes #25.