### PR TITLE
Fixes #31 Memory leak in 0.9.12

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -264,7 +264,7 @@ sync.fiber = function(cb, done){
   var that = this
   var fiber = Fiber(function(){
     // Prevent restart fiber
-    if (fiber._started) return
+    if (Fiber.current._started) return
     if (done) {
       var result
       try {


### PR DESCRIPTION
Simple test case:

    var immediately = function(cb) {
        sync.fiber(function() {
            setImmediate(sync.defer());
            sync.await();
        }, cb);
    };

    function test(m, cb) {
        if (m-- === 0) return cb();
        immediately(function(err) {
            if (err) return cb(err);
            if (m % 1000 === 0) {
                console.log(m + ": " + JSON.stringify(process.memoryUsage()));
            }
            test(m, cb);
        });
    }

    test(100000000, function(err) {
            if (err) throw err;
            console.log("done");
    });

Before:
    99888000: {"rss":114892800,"heapTotal":81994496,"heapUsed":58052656}
    99887000: {"rss":115163136,"heapTotal":81994496,"heapUsed":59327264}
    99886000: {"rss":115433472,"heapTotal":83026432,"heapUsed":60601944}
    99885000: {"rss":115703808,"heapTotal":83026432,"heapUsed":61877016}
    99884000: {"rss":115974144,"heapTotal":83026432,"heapUsed":63152072}
    99883000: {"rss":120840192,"heapTotal":87154176,"heapUsed":56497944}
    99882000: {"rss":121110528,"heapTotal":87154176,"heapUsed":57772688}

After:
    99687000: {"rss":74567680,"heapTotal":60323840,"heapUsed":36945504}
    99686000: {"rss":74567680,"heapTotal":60323840,"heapUsed":38211632}
    99685000: {"rss":74510336,"heapTotal":59291904,"heapUsed":16835640}
    99684000: {"rss":74510336,"heapTotal":59291904,"heapUsed":18102288}
    99683000: {"rss":74510336,"heapTotal":59291904,"heapUsed":19368336}
    99682000: {"rss":74510336,"heapTotal":59291904,"heapUsed":20634792}
    99681000: {"rss":74510336,"heapTotal":59291904,"heapUsed":21900840}
    99680000: {"rss":74510336,"heapTotal":59291904,"heapUsed":23166888}
    99679000: {"rss":74510336,"heapTotal":59291904,"heapUsed":24432936}