### PR TITLE
Compatibility with node v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/alexeypetrushin/synchronize.git"
   },
   "dependencies" : {
-    "fibers" : "1.0.x"
+    "fibers" : "1.0.14"
   },
   "devDependencies" : {
     "mocha" : "1.0.x",


### PR DESCRIPTION
According to fibers author node v5 won't be supported with pre-built binaries.
https://github.com/laverdet/node-fibers/issues/313#issuecomment-252325772