### PR TITLE
fix travis repo badge link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Documentation [http://alexeypetrushin.github.com/synchronize](http://alexeypetru
 
 Installation `npm install synchronize`
 
-![Build Status](https://travis-ci.org/alexeypetrushin/synchronize.svg)
+[![Build Status](https://travis-ci.org/alexeypetrushin/synchronize.svg)](https://travis-ci.org/alexeypetrushin/synchronize)
 
 Contributors:
 


### PR DESCRIPTION
this wraps the badge in an anchor tag to the travis page