### PR TITLE
Fix bugs in error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "synchronize",
   "main": "./sync",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "http://alexeypetrushin.github.com/synchronize",
   "repository": {
     "type": "git",

--- a/sync.js
+++ b/sync.js
@@ -260,17 +260,19 @@ sync.parallel = function(cb){
 }
 
 function decorateError(error, callStack){
-  var errorStack = error.stack;
-  Object.defineProperties(error, {
-    stack: {
-      get: function () {
-        if (!callStack) {
+  if (typeof error === 'object') {
+    var errorStack = error.stack;
+    Object.defineProperties(error, {
+      stack: {
+        get: function () {
+          if (!callStack) {
             return errorStack;
+          }
+          return [errorStack, callStack.substring(callStack.indexOf('\n') + 1)].join('\n')
         }
-        return [errorStack, callStack.substring(callStack.indexOf('\n') + 1)].join('\n')
       }
-    }
-  });
+    });
+  }
   return error;
 }
 

--- a/sync.js
+++ b/sync.js
@@ -264,6 +264,7 @@ function decorateError(error, callStack){
     var errorStack = error.stack;
     Object.defineProperties(error, {
       stack: {
+        configurable: true,
         get: function () {
           if (!callStack) {
             return errorStack;


### PR DESCRIPTION
We were running into issues when an error fired within nested fibers. This is because defineProperties sets the property as immutable. Which the next fiber then tries to set to the new callback, causing your program to crash. This is fixed by setting the `configurable` property to true.

Another issue we encountered was that synchronize crashes if `decorateError` encounters a non-object error for some reason. This can be fixed by explicitly checking if error is an object before calling defineProperties.