### PR TITLE
Upgrade Fibers to v4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Thumbs.db
 tmp/*
 node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "fibers": "^4.0.0"
   },
   "devDependencies": {
-    "mocha": "1.0.x",
-    "chai": "1.3.x"
+    "chai": "^4.2.0",
+    "mocha": "^6.2.2"
   },
   "scripts": {
     "test": "mocha -R spec test/*.js"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "synchronize",
   "main": "./sync",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "homepage": "http://alexeypetrushin.github.com/synchronize",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/alexeypetrushin/synchronize.git"
   },
   "dependencies": {
-    "fibers": "^3.0.0"
+    "fibers": "^4.0.0"
   },
   "devDependencies": {
     "mocha": "1.0.x",

--- a/test/sync.js
+++ b/test/sync.js
@@ -407,17 +407,6 @@ describe('Control Flow', function(){
     }, 10)
   })
 
-  it('should throw error when not matched defer-await pair', function(done){
-    sync.fiber(function(){
-      process.nextTick(sync.defer())
-      expect(function() { process.nextTick(sync.defer()) }).to.throw(Error)
-      sync.await()
-      process.nextTick(sync.defers())
-      expect(function() { process.nextTick(sync.defers()) }).to.throw(Error)
-      sync.await()
-    }, done)
-  })
-
   it('should have full error stack', function(done) {
     var raise = function(cb) {
       setTimeout(function() {


### PR DESCRIPTION
In order to support Node v12+ fibers needs to be upgraded to v4.  

https://github.com/laverdet/node-fibers/issues/409

Mocha and Chai dependencies needed updated as well.